### PR TITLE
Hi did some modifictation to your plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Set the display clock only when there is a file in view or display always like b
 Set the format of the time using the StatusBarTime__format setting. Defaults to '%H:%M:%S'
 
 Example:
+
     "StatusBarClock_type": 1    // Now it will display sublime text uptime
     
     "StatusBarClock_Interval": 5000 // Now clock will be updated every 5 sec

--- a/README.md
+++ b/README.md
@@ -15,10 +15,21 @@ Using [Package Control](http://wbond.net/sublime_packages/package_control):
 
 ## Settings
 
+Set clock type as sublime text uptime
+
+Set the clock update interval
+
+Set the display clock only when there is a file in view or display always like before
+
 Set the format of the time using the StatusBarTime__format setting. Defaults to '%H:%M:%S'
 
 Example:
-
+    "StatusBarClock_type": 1    // Now it will display sublime text uptime
+    
+    "StatusBarClock_Interval": 5000 // Now clock will be updated every 5 sec
+    
+    "StatusBarClock_display_onlyinview": true   // Now clock will only be displayed when there is a file in view
+    
     "StatusBarTime_format": "%a - %H:%M:%S" // Mon - 22:58:24
 
 For more information refer to [documentation](http://docs.python.org/2/library/time.html#time.strftime)

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -5,21 +5,66 @@
 import sublime, sublime_plugin
 from datetime import datetime
 
+STATUSBARTIME_FORMAT_KEY = 'StatusBarTime_format'
+STATUSBARTIME_CLOCK_TYPE_KEY = 'StatusBarClock_Type'
+STATUSBARTIME_SETTING_FILE = 'StatusBarTime.sublime-settings'
+STATUSBARTIME_CLOCKDELAY_KEY = 'StatusBarClock_Interval'
+STATUSBARTIME_CLOCKDISPLAY_ONLYINVIEW_KEY = "StatusBarClock_display_onlyinview"
+DEFAULT_FORMAT = '%H:%M:%S'
+
 class StatusBarTime(sublime_plugin.EventListener):
+    stBarStartTime = 0  # variable to hold start time
     def on_activated(self, view):
-        settings = sublime.load_settings('StatusBarTime.sublime-settings')
-        Timer(settings.get(STATUSBARTIME_FORMAT_KEY, DEFAULT_FORMAT)).displayTime(view)
+        settings = sublime.load_settings(STATUSBARTIME_SETTING_FILE)
+        # Get Update interval for clock
+        update_interval = settings.get(STATUSBARTIME_CLOCKDELAY_KEY, 1000)
+        # New Setting load From setting file
+        clock_Type = settings.get(STATUSBARTIME_CLOCK_TYPE_KEY, 0)
+        # Get setting for only in view display
+        onlyinview = settings.get(STATUSBARTIME_CLOCKDISPLAY_ONLYINVIEW_KEY, True)
+        # Start Timer if its empty (This is supposed to happen only once)
+        if not self.stBarStartTime: self.stBarStartTime=datetime.now()
+        if not clock_Type: Timer(settings.get(STATUSBARTIME_FORMAT_KEY, DEFAULT_FORMAT)).displayTime(view, update_interval, onlyinview)
+        else: Timer().displayUpTime(view, self.stBarStartTime, update_interval, onlyinview)
 
 class Timer():
-    def __init__(self, format):
+    status_key = 'statusclock'
+    def __init__(self, format=DEFAULT_FORMAT):
         self._format = format
 
-    def displayTime(self, view):
-        view.set_status('time', datetime.now().strftime(self._format))
-        if sublime.active_window().active_view().id() == view.id():
-            sublime.set_timeout(lambda: self.displayTime(view), 1000)
+    # helper method which converts given duration to days, hours, minutes and seconds
+    def convert_timedelta(self, duration):
+        days, seconds = duration.days, duration.seconds
+        hours = seconds//3600
+        minutes = (seconds % 3600)//60
+        seconds = seconds % 60
+        return days, hours, minutes, seconds
+    
+    def displayTime(self, view, delay, onlyinview):
+        view.set_status(self.status_key, datetime.now().strftime(self._format))
+        actwin = sublime.active_window()
+        if actwin:
+            if not onlyinview or (actwin.active_view() and actwin.active_view().id() == view.id()):
+               sublime.set_timeout(lambda: self.displayTime(view, delay, onlyinview), delay)
         else:
-            view.set_status('time', '')
-
-STATUSBARTIME_FORMAT_KEY = 'StatusBarTime_format'
-DEFAULT_FORMAT = '%H:%M:%S'
+            view.set_status(self.status_key, '')
+        return
+        
+    # Method for handling uptime display
+    def displayUpTime(self, view, startTime, delay, onlyinview):
+        upTime = datetime.now() - startTime
+        days, hours, minutes, seconds = self.convert_timedelta(upTime)
+        out = ''
+        if days: out += str("%s days, " % (days))
+        if hours: out += str("%02d:%02d:%02d" % (hours, minutes, seconds))
+        elif minutes: out += str("%02d:%02d" % (minutes, seconds))
+        elif seconds: out += str("%02d seconds" % (seconds))
+        view.set_status(self.status_key, out)
+        actwin = sublime.active_window()
+        if actwin:
+            if not onlyinview or (actwin.active_view() and actwin.active_view().id() == view.id()):
+               sublime.set_timeout(lambda: self.displayUpTime(view, startTime, delay, onlyinview), delay)
+        else:
+            view.set_status(self.status_key, '')
+        return
+        

--- a/StatusBarTime.sublime-settings
+++ b/StatusBarTime.sublime-settings
@@ -1,8 +1,19 @@
 {
-	// Specifies date / time format, where:
-	// %H - Hour (24-hour clock) as a decimal number [00, 23]
-	// %M - Minute as a decimal number [00, 59]
-	// %S - Second as a decimal number [00, 61]
-	// For more information, please refer to: http://docs.python.org/2/library/time.html#time.strftime
-    "StatusBarTime_format": "%H:%M:%S"
+    // Clock update interval
+    "StatusBarClock_Interval": 1000,
+    
+    // Display only when there is a view (Making it false will turn clock always even when there is no file in view)
+    "StatusBarClock_display_onlyinview": false,
+    
+    // Specifies date / time format, where:
+    // %H - Hour (24-hour clock) as a decimal number [00, 23]
+    // %M - Minute as a decimal number [00, 59]
+    // %S - Second as a decimal number [00, 61]
+    // For more information, please refer to: http://docs.python.org/2/library/time.html#time.strftime
+    "StatusBarTime_format": "%H:%M:%S",
+    
+    // Specifies Clock type
+    // 0 - System clock
+    // 1 - Sublime Up time
+    "StatusBarClock_type": 0
 }


### PR DESCRIPTION
Added new feature to show sublime up time helps you to know how long you working

Add: Control clock update interval from setting file
Add: setting to display clock only when there is a file in view 
     or display always like before
Add: Show sublime uptime helps you to know how long you working
Fixed: AttributeError: 'NoneType' object has no attribute 'active_view'
Which was caused when there was no file in view

Use it if you like
