### PR TITLE
Add lefty setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Example config:
     // Time format, for "%a - %H:%M:%S" -> Mon - 22:58:24
     "StatusBarTime_format": "%H:%M:%S"
 
+    // Stick the clock on the left side of the status bar
+    "StatusBarClock_lefty": true,
+
 For more information refer to [Python documentation](http://docs.python.org/2/library/time.html#time.strftime)
 
 --------------

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -31,7 +31,7 @@ class StatusBarTime(sublime_plugin.EventListener):
         else: Timer().displayUpTime(view, self.stBarStartTime, update_interval, onlyinview, lefty)
 
 class Timer():
-    status_key = "statusclock"
+    status_key = 'statusclock'
     def __init__(self, format=DEFAULT_FORMAT):
         self._format = format
 

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -50,7 +50,7 @@ class Timer():
         actwin = sublime.active_window()
         if actwin:
             if not onlyinview or (actwin.active_view() and actwin.active_view().id() == view.id()):
-               sublime.set_timeout(lambda: self.displayTime(view, delay, onlyinview), delay)
+               sublime.set_timeout(lambda: self.displayTime(view, delay, onlyinview, lefty), delay)
         else:
             view.set_status(self.status_key, '')
         return

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -10,6 +10,7 @@ STATUSBARTIME_CLOCK_TYPE_KEY = 'StatusBarClock_Type'
 STATUSBARTIME_SETTING_FILE = 'StatusBarTime.sublime-settings'
 STATUSBARTIME_CLOCKDELAY_KEY = 'StatusBarClock_Interval'
 STATUSBARTIME_CLOCKDISPLAY_ONLYINVIEW_KEY = "StatusBarClock_display_onlyinview"
+STATUSBARTIME_LEFTY_KEY = 'StatusBarClock_lefty'
 DEFAULT_FORMAT = '%H:%M:%S'
 
 class StatusBarTime(sublime_plugin.EventListener):
@@ -22,13 +23,15 @@ class StatusBarTime(sublime_plugin.EventListener):
         clock_Type = settings.get(STATUSBARTIME_CLOCK_TYPE_KEY, 0)
         # Get setting for only in view display
         onlyinview = settings.get(STATUSBARTIME_CLOCKDISPLAY_ONLYINVIEW_KEY, True)
+        # Get setting for clock right display
+        lefty = settings.get(STATUSBARTIME_LEFTY_KEY, True)
         # Start Timer if its empty (This is supposed to happen only once)
         if not self.stBarStartTime: self.stBarStartTime=datetime.now()
-        if not clock_Type: Timer(settings.get(STATUSBARTIME_FORMAT_KEY, DEFAULT_FORMAT)).displayTime(view, update_interval, onlyinview)
-        else: Timer().displayUpTime(view, self.stBarStartTime, update_interval, onlyinview)
+        if not clock_Type: Timer(settings.get(STATUSBARTIME_FORMAT_KEY, DEFAULT_FORMAT)).displayTime(view, update_interval, onlyinview, lefty)
+        else: Timer().displayUpTime(view, self.stBarStartTime, update_interval, onlyinview, lefty)
 
 class Timer():
-    status_key = 'statusclock'
+    status_key = "statusclock"
     def __init__(self, format=DEFAULT_FORMAT):
         self._format = format
 
@@ -39,8 +42,10 @@ class Timer():
         minutes = (seconds % 3600)//60
         seconds = seconds % 60
         return days, hours, minutes, seconds
-    
-    def displayTime(self, view, delay, onlyinview):
+
+    def displayTime(self, view, delay, onlyinview, lefty):
+        if lefty:
+            self.status_key = "0statusclock"
         view.set_status(self.status_key, datetime.now().strftime(self._format))
         actwin = sublime.active_window()
         if actwin:
@@ -49,7 +54,7 @@ class Timer():
         else:
             view.set_status(self.status_key, '')
         return
-        
+
     # Method for handling uptime display
     def displayUpTime(self, view, startTime, delay, onlyinview):
         upTime = datetime.now() - startTime
@@ -67,4 +72,4 @@ class Timer():
         else:
             view.set_status(self.status_key, '')
         return
-        
+

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -45,7 +45,7 @@ class Timer():
 
     def displayTime(self, view, delay, onlyinview, lefty):
         if lefty:
-            self.status_key = "0statusclock"
+            self.status_key = "__statusclock"
         view.set_status(self.status_key, datetime.now().strftime(self._format))
         actwin = sublime.active_window()
         if actwin:

--- a/StatusBarTime.py
+++ b/StatusBarTime.py
@@ -23,7 +23,7 @@ class StatusBarTime(sublime_plugin.EventListener):
         clock_Type = settings.get(STATUSBARTIME_CLOCK_TYPE_KEY, 0)
         # Get setting for only in view display
         onlyinview = settings.get(STATUSBARTIME_CLOCKDISPLAY_ONLYINVIEW_KEY, True)
-        # Get setting for clock right display
+        # Get setting for lefty display
         lefty = settings.get(STATUSBARTIME_LEFTY_KEY, True)
         # Start Timer if its empty (This is supposed to happen only once)
         if not self.stBarStartTime: self.stBarStartTime=datetime.now()

--- a/StatusBarTime.sublime-settings
+++ b/StatusBarTime.sublime-settings
@@ -18,5 +18,5 @@
     "StatusBarClock_type": 0,
 
     // Stick the clock on the left side of the status bar
-    "StatusBarClock_lefty": true,
+    "StatusBarClock_lefty": true
 }

--- a/StatusBarTime.sublime-settings
+++ b/StatusBarTime.sublime-settings
@@ -1,19 +1,22 @@
 {
     // Clock update interval
     "StatusBarClock_Interval": 1000,
-    
+
     // Display only when there is a view (Making it false will turn clock always even when there is no file in view)
     "StatusBarClock_display_onlyinview": false,
-    
+
     // Specifies date / time format, where:
     // %H - Hour (24-hour clock) as a decimal number [00, 23]
     // %M - Minute as a decimal number [00, 59]
     // %S - Second as a decimal number [00, 61]
     // For more information, please refer to: http://docs.python.org/2/library/time.html#time.strftime
     "StatusBarTime_format": "%H:%M:%S",
-    
+
     // Specifies Clock type
     // 0 - System clock
     // 1 - Sublime Up time
-    "StatusBarClock_type": 0
+    "StatusBarClock_type": 0,
+
+    // Stick the clock on the left side of the status bar
+    "StatusBarClock_lefty": true,
 }


### PR DESCRIPTION
I added a new setting to stick the clock to the left of the status bar. I think it's easier to see the clock when it's always on the left since many plugins like Git also display information on the status bar.
